### PR TITLE
Fix in ubuntu 20.04

### DIFF
--- a/main.py
+++ b/main.py
@@ -78,10 +78,10 @@ class SshExtension(Extension):
         shell = os.environ["SHELL"]
         home = expanduser("~")
 
-        cmd = self.terminal_cmd.replace("%SHELL", shell).replace("%CONN", addr)
+        cmd = "ssh %CONN".replace("%CONN", addr)
 
         if self.terminal:
-            subprocess.Popen([self.terminal, self.terminal_arg, cmd], cwd=home)
+            subprocess.Popen([self.terminal, self.terminal_arg, shell, '-c', cmd, ';', shell], cwd=home)
 
 class ItemEnterEventListener(EventListener):
 


### PR DESCRIPTION
subprocess.Popen(["alacritty", "-e", "/bin/bash -c 'ssh trackin.pgsql';/bin/bash"], cwd='/home/user')  -- this make the result is  'No such file or directory'
so i change with 
subprocess.Popen(["alacritty", "-e", "/bin/bash", "-c", 'ssh trackin.pgsql', ";", "/bin/bash"], cwd="/home/user") -- this open the terminal